### PR TITLE
Add zero-allocation bulk APIs and optimize UUIDv7 generation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@
 `uuidv7` is a small, dependency-free Java library for generating RFC 9562 UUID version 7 identifiers.
 It is designed for production workloads that care about time ordering, throughput, low allocation pressure, and multicore scalability.
 
-The library exposes two generation modes:
+The library exposes the following generation APIs:
 
-- `UUIDv7.randomUUID()` is the default high-throughput API. It uses per-thread state, avoids shared hot-path contention, and preserves monotonic ordering for values produced by the same thread within the same millisecond.
-- `UUIDv7.secureRandomUUID()` is the stronger-entropy API. It uses `SecureRandom` to seed and advance the UUID state, which improves unpredictability at a much higher per-call cost.
+- `UUIDv7.randomUUID()` — the default high-throughput API. Per-thread state, no shared hot-path contention, monotonic ordering for values produced by the same thread.
+- `UUIDv7.fill(long[]/byte[], offset, count)` — bulk generation with **zero allocations**. The clock is read once per batch; this is the fastest API (sub-nanosecond per UUID).
+- `UUIDv7.randomUUIDString()` — canonical 36-character string form without materializing an intermediate `UUID`.
+- `UUIDv7Generator` — a caller-owned, single-threaded generator instance for code that already confines work per thread (event loops, actors, partitions). Not thread-safe by design.
+- `UUIDv7.secureRandomUUID()` — the stronger-entropy API, backed by `SecureRandom` with buffered entropy.
 
 ## Features
 
@@ -18,10 +21,14 @@ The library exposes two generation modes:
 - 48-bit Unix epoch timestamp in milliseconds
 - Correct version and variant bits
 - Clock rollback handling
-- Same-millisecond monotonic sequencing
+- Same-millisecond monotonic sequencing with guaranteed counter headroom (RFC 9562 §6.2 counter seeding)
+- Bulk APIs (`long[]` pairs or RFC big-endian `byte[]`) with zero allocations
+- Virtual-thread aware: virtual threads are transparently routed to a striped generator pool (Java 21+), so per-request state churn and per-thread `SecureRandom` construction never happen
+- Optional cached clock mode for clock-read-bound platforms (opt-in system property)
+- GraalVM native image ready: run-time initialization metadata is embedded in the JAR, so image builds never freeze the random seed state
 - No runtime dependencies beyond the JDK
 - Java 17+
-- Fast path allocates only the returned `UUID` object
+- Fast path allocates only the returned `UUID` object; bulk paths allocate nothing
 
 ## Quick Start
 
@@ -39,16 +46,42 @@ The library exposes two generation modes:
 
 ```java
 import io.github.robsonkades.uuidv7.UUIDv7;
+import io.github.robsonkades.uuidv7.UUIDv7Generator;
 
 import java.util.UUID;
 
+// Default APIs — always thread-safe (platform and virtual threads)
 UUID fast = UUIDv7.randomUUID();
+String key = UUIDv7.randomUUIDString();
 UUID secure = UUIDv7.secureRandomUUID();
+
+// Bulk generation — zero allocations, clock read once per batch
+long[] pairs = new long[2 * 1024];
+UUIDv7.fill(pairs, 0, 1024);            // (msb, lsb) pairs
+
+byte[] raw = new byte[16 * 1024];
+UUIDv7.fill(raw, 0, 1024);              // RFC 9562 big-endian binary layout
+
+// Instance API — for thread-confined code; NOT thread-safe
+UUIDv7Generator generator = UUIDv7Generator.create();
+UUID id = generator.next();
 ```
+
+### Cached clock (opt-in)
+
+Since the UUIDv7 timestamp has millisecond granularity, the wall clock only needs to be observed about once per millisecond. Enabling:
+
+```
+-Dio.github.robsonkades.uuidv7.cachedClock=true
+```
+
+starts a daemon thread that refreshes a volatile timestamp every ~0.5 ms, replacing the `System.currentTimeMillis()` call on the hot path with a plain volatile read. The monotonic state machine absorbs the 1–2 ms jitter, so ordering and uniqueness are unaffected; only the embedded creation timestamp may lag the true wall clock by that amount. The win is largest on platforms where reading the wall clock is expensive (e.g. Linux `CLOCK_REALTIME` via vDSO); on Windows the default clock is already cheap.
 
 ### Which API should I use?
 
 - Use `UUIDv7.randomUUID()` for database keys, event IDs, trace IDs, queue message IDs, and other high-volume identifiers.
+- Use `UUIDv7.fill(...)` when generating identifiers in batches (bulk inserts, event batching, ID pre-allocation) — it is ~6x faster per UUID and allocates nothing.
+- Use `UUIDv7Generator` when your architecture already confines work to a thread and you want to own the generator state placement.
 - Use `UUIDv7.secureRandomUUID()` only if stronger entropy in the UUID payload matters more than raw throughput.
 - Do not use UUIDv7 as a secret token format. UUIDv7 embeds creation time by design.
 
@@ -56,79 +89,109 @@ UUID secure = UUIDv7.secureRandomUUID();
 
 The implementation is intentionally optimized around the real bottlenecks of UUID generation on the JVM:
 
-- The fast generator keeps mutable state in `ThreadLocal` storage, which avoids global locks, atomics, and cache-line ping-pong under contention.
+- The fast generator keeps mutable state in `ThreadLocal` storage, which avoids global locks, atomics, and cache-line ping-pong under contention. Virtual threads are detected (via a JIT-constant method-handle probe, so the check is free) and routed to a striped, lock-guarded pool instead, bounding state churn and `SecureRandom` construction.
 - UUID bit packing is done directly into two `long` values. No `byte[16]`, `ByteBuffer`, boxing, or formatting work happens on the hot path.
+- The monotonic `rand_b` counter is reseeded each millisecond with its two most significant bits clear, following the counter-seeding guidance of RFC 9562 Section 6.2. Every millisecond therefore starts with at least 2^60 increments of headroom, making counter rollover unreachable in practice.
 - If the wall clock moves backwards, the generator reuses the last logical timestamp and advances monotonic state instead of emitting a smaller UUID.
-- If the same-millisecond counter space is exhausted, the generator advances to the next logical millisecond rather than knowingly wrapping and returning duplicates.
-- The secure generator keeps the same state machine, but uses `SecureRandom` to seed new timestamps and to advance same-millisecond state with positive random increments.
+- Generator state objects carry cache-line padding on both sides, so a compacting GC can never relocate two threads' states onto the same cache line (no false sharing regardless of heap layout).
+- The secure generator keeps the same state machine, but draws bits from `SecureRandom` in buffered 512-byte blocks, amortizing the provider cost and its internal lock over dozens of UUIDs instead of paying a full `nextLong()` round trip per UUID.
+- On GraalVM native image, the package is initialized at run time (metadata embedded in the JAR), so random seeds are never baked into the image heap at build time.
 
 ## Benchmark Methodology
 
 Benchmarks were run with JMH 1.37 on this repository's current implementation and benchmark suite.
 
-- JVM: GraalVM CE 25.0.2
-- Hardware: 24 logical CPUs
+- JVM: Temurin OpenJDK 25.0.3
+- OS: Windows 11
+- Hardware: Intel Core i7-13700K (16 cores / 24 threads, hybrid P+E topology)
 - JVM args: `-Xms1g -Xmx1g`
 - Warmup: 5 iterations x 1 second
 - Measurement: 5 iterations x 1 second
 - Forks: 2
+- Contended benchmarks: 8 threads (`@Threads(8)`)
 - Benchmark source: `src/test/java/io/github/robsonkades/uuidv7/UUIDv7Benchmark.java`
 
 Comparison targets:
 
 - `optimizedFast`: `UUIDv7.randomUUID()`
+- `optimizedFillLongBatch` / `optimizedFillByteBatch`: `UUIDv7.fill(...)`, 256 UUIDs per batch
+- `optimizedGeneratorInstance`: `UUIDv7Generator.next()`
+- `optimizedFastString`: `UUIDv7.randomUUIDString()`
 - `optimizedSecure`: `UUIDv7.secureRandomUUID()`
-- `legacyThreadLocalRandom`: previous no-state baseline
+- `legacyThreadLocalRandom`: bare `ThreadLocalRandom` baseline with no monotonicity or rollback handling
 - `naiveSecureRandomByteBuffer`: `SecureRandom` + `byte[16]` + `ByteBuffer`
-- `uuidCreator`: `com.github.f4b6a3:uuid-creator`
-- `uuidCreatorFast`: `com.github.f4b6a3:uuid-creator` fast mode
-- `jugEpoch`: `com.fasterxml.uuid:java-uuid-generator`
+- `uuidCreator` / `uuidCreatorFast`: `com.github.f4b6a3:uuid-creator` 6.1.1
+- `jugEpoch`: `com.fasterxml.uuid:java-uuid-generator` 5.2.0
 
-These results are point-in-time measurements, not universal constants. Different JVMs, CPU topologies, entropy providers, and OS timer behavior will change the exact numbers.
+These results are point-in-time measurements, not universal constants. Different JVMs, CPU topologies, entropy providers, and OS timer behavior will change the exact numbers. In particular, Windows reads the wall clock very cheaply; on Linux the optional cached clock mode recovers most of the (larger) vDSO clock cost.
 
 ## Benchmark Results
 
 ### Single-Thread Throughput
 
-| Implementation | Throughput | Allocation |
+| Implementation | Throughput | ns/UUID |
 |---|---:|---:|
-| `optimizedFast` | 250.3 M ops/s | 32.0 B/op |
-| `legacyThreadLocalRandom` | 279.1 M ops/s | 32.0 B/op |
-| `jugEpoch` | 69.4 M ops/s | 32.0 B/op |
-| `uuidCreatorFast` | 35.7 M ops/s | 64.0 B/op |
-| `naiveSecureRandomByteBuffer` | 3.75 M ops/s | 208.0 B/op |
-| `uuidCreator` | 3.59 M ops/s | 231.3 B/op |
-| `optimizedSecure` | 1.86 M ops/s | 368.2 B/op |
+| `optimizedFillLongBatch` | 1.473 B ops/s | 0.68 |
+| `optimizedFillByteBatch` | 1.177 B ops/s | 0.85 |
+| `optimizedFast` | 248.4 M ops/s | 4.03 |
+| `legacyThreadLocalRandom` | 248.1 M ops/s | 4.03 |
+| `optimizedGeneratorInstance` | 247.7 M ops/s | 4.04 |
+| `optimizedSecure` | 121.4 M ops/s | 8.24 |
+| `jugEpoch` | 74.2 M ops/s | 13.5 |
+| `optimizedFastString` | 49.0 M ops/s | 20.4 |
+| `uuidCreatorFast` | 33.8 M ops/s | 29.6 |
+| `naiveSecureRandomByteBuffer` | 3.99 M ops/s | 251 |
+| `uuidCreator` | 3.67 M ops/s | 272 |
 
-### 24-Thread Throughput
+The bulk `fill` APIs allocate nothing; the unit APIs allocate only the returned `UUID` (32 B/op) or `String`.
 
-| Implementation | Throughput | Allocation |
+### Contended Throughput (8 threads)
+
+| Implementation | Throughput | vs single-thread |
 |---|---:|---:|
-| `optimizedFast` | 1.069 B ops/s | 32.0 B/op |
-| `legacyThreadLocalRandom` | 1.081 B ops/s | 32.0 B/op |
-| `uuidCreatorFast` | 27.8 M ops/s | 64.3 B/op |
-| `optimizedSecure` | 21.8 M ops/s | 368.4 B/op |
-| `jugEpoch` | 10.6 M ops/s | 32.6 B/op |
-| `uuidCreator` | 2.44 M ops/s | 225.0 B/op |
-| `naiveSecureRandomByteBuffer` | 2.23 M ops/s | 208.0 B/op |
+| `contendedOptimizedFast` | 1.053 B ops/s | 4.2x (scales) |
+| `contendedUuidCreatorFast` | 24.9 M ops/s | 0.74x (regresses) |
+| `contendedJugEpoch` | 8.8 M ops/s | 0.12x (collapses) |
 
 ### Single-Thread Sample Latency
 
-| Implementation | Mean | p95 | p99 | p99.9 |
-|---|---:|---:|---:|---:|
-| `optimizedFast` | 32.1 ns | 100 ns | 100 ns | 221.3 ns |
-| `jugEpoch` | 38.6 ns | 100 ns | 100 ns | 300.0 ns |
-| `uuidCreatorFast` | 54.4 ns | 100 ns | 100 ns | 400.0 ns |
-| `naiveSecureRandomByteBuffer` | 328.7 ns | 300 ns | 400 ns | 9486.7 ns |
+| Implementation | Mean | p99 | p99.9 | p99.99 | Max |
+|---|---:|---:|---:|---:|---:|
+| `optimizedFast` | 32.5 ns | ≤100 ns | 200 ns | 18.8 µs | 133 µs |
+| `jugEpoch` | 45.1 ns | ≤100 ns | 600 ns | 14.4 µs | 869 µs |
+| `uuidCreatorFast` | 62.0 ns | ≤100 ns | 900 ns | 32.6 µs | 407 µs |
+| `naiveSecureRandomByteBuffer` | 298.2 ns | 400 ns | 9.9 µs | 60.9 µs | 1.18 ms |
+
+Sample-time percentiles at or below 100 ns are limited by the ~100 ns timer granularity on Windows (that is also why p50 reports as 0). The p99.99 outliers on all implementations are OS scheduling and safepoint noise, not generator behavior.
 
 ## Reading the Results
 
-- `optimizedFast` stays close to the bare `ThreadLocalRandom` baseline in single-thread mode while adding rollback handling and same-thread monotonic sequencing.
-- Under 24-thread load, `optimizedFast` scales essentially linearly and remains near the legacy baseline, which is the main design goal of the implementation.
-- `optimizedFast` is about 67x faster than the naive `SecureRandom + ByteBuffer` baseline in single-thread throughput and about 480x faster at 24 threads.
-- `optimizedFast` is about 7x faster than `uuidCreatorFast` in single-thread throughput and about 38x faster at 24 threads.
-- `jugEpoch` and `uuidCreator` show a large collapse under contention, which strongly suggests shared internal coordination costs.
-- `optimizedSecure` is intentionally much slower than `optimizedFast`. That is the expected trade-off for stronger entropy and random monotonic increments.
+- `optimizedFast` is statistically identical to the bare `ThreadLocalRandom` baseline (248.4 M vs 248.1 M ops/s): the monotonic sequencing, rollback handling, and RFC 9562 counter-seeding machinery cost nothing measurable.
+- The bulk `fill(long[])` API reaches **~0.68 ns per UUID** — about 5.9x the unit API — by reading the clock once per batch and keeping the generator state in registers, with zero allocations.
+- `optimizedSecure` now runs at **121.4 M ops/s**, roughly 65x faster than the previous unbuffered implementation of this same library (1.86 M ops/s), thanks to 512-byte buffered entropy. The secure path is now only ~2x slower than the fast path, ~30x faster than the naive `SecureRandom` baseline, and ~33x faster than `uuidCreator`'s default generator.
+- Under 8-thread load, `optimizedFast` reaches 1.05 B ops/s while both comparison libraries drop **below their own single-thread numbers** (`uuidCreatorFast` 33.8 M → 24.9 M; `jugEpoch` 74.2 M → 8.8 M), which is the signature of a shared global sequencer. Per-thread scaling here is bounded by the hybrid P+E core topology, not by coordination: there is no shared state between platform threads.
+- `optimizedGeneratorInstance` ties `optimizedFast` on this JVM: `ThreadLocal.get()` on modern JDKs is below measurement noise on this hardware. The instance API's value is architectural (caller-owned state placement, no thread-local map dependency) rather than raw single-thread speed.
+- Tail latency is the best of the group: p99.9 of 200 ns vs 600 ns (`jugEpoch`) and 900 ns (`uuidCreatorFast`).
+- `optimizedFastString` shows that string formatting (~20 ns/op) dominates UUID generation (~4 ns/op) — if you only need the string form, `randomUUIDString()` still saves the intermediate `UUID` allocation over `randomUUID().toString()`.
+
+## Running the Benchmarks
+
+```bash
+# Build the executable benchmark jar
+mvn -Pbenchmarks -DskipTests package
+
+# Full suite (~15-20 minutes)
+java -jar target/benchmarks.jar UUIDv7Benchmark
+
+# Single benchmark, allocation profiling, contended group
+java -jar target/benchmarks.jar 'UUIDv7Benchmark.optimizedFast$'
+java -jar target/benchmarks.jar UUIDv7Benchmark -prof gc
+java -jar target/benchmarks.jar UUIDv7Benchmark.contended
+
+# With the cached clock enabled
+java -jar target/benchmarks.jar 'UUIDv7Benchmark.optimizedFast$' \
+  -jvmArgs "-Xms1g -Xmx1g -Dio.github.robsonkades.uuidv7.cachedClock=true"
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.robsonkades/uuidv7)](https://search.maven.org/artifact/io.github.robsonkades/uuidv7)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://github.com/robsonkades/uuid/actions/workflows/maven.yml/badge.svg)](https://github.com/robsonkades/uuid/actions)
+[![javadoc](https://javadoc.io/badge2/io.github.robsonkades/uuidv7/javadoc.svg)](https://javadoc.io/doc/io.github.robsonkades/uuidv7)
 
 `uuidv7` is a small, dependency-free Java library for generating RFC 9562 UUID version 7 identifiers.
 It is designed for production workloads that care about time ordering, throughput, low allocation pressure, and multicore scalability.

--- a/pom.xml
+++ b/pom.xml
@@ -152,4 +152,50 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- Builds an executable JMH uber-jar at target/benchmarks.jar.
+                 Usage:
+                   mvn -Pbenchmarks -DskipTests package
+                   java -jar target/benchmarks.jar UUIDv7Benchmark -->
+            <id>benchmarks</id>
+            <properties>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <maven.source.skip>true</maven.source.skip>
+                <gpg.skip>true</gpg.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.7.1</version>
+                        <executions>
+                            <execution>
+                                <id>benchmarks-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>benchmarks</finalName>
+                                    <appendAssemblyId>false</appendAssemblyId>
+                                    <attach>false</attach>
+                                    <descriptors>
+                                        <descriptor>src/assembly/benchmarks.xml</descriptor>
+                                    </descriptors>
+                                    <archive>
+                                        <manifest>
+                                            <mainClass>org.openjdk.jmh.Main</mainClass>
+                                        </manifest>
+                                    </archive>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/assembly/benchmarks.xml
+++ b/src/assembly/benchmarks.xml
@@ -1,0 +1,37 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <!-- Executable JMH uber-jar built from the TEST classpath, where the
+         benchmarks and their generated JMH metadata live. -->
+    <id>benchmarks</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <scope>test</scope>
+            <unpack>true</unpack>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpackOptions>
+                <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
+                </excludes>
+            </unpackOptions>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.outputDirectory}</directory>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.testOutputDirectory}</directory>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/main/java/io/github/robsonkades/uuidv7/UUIDv7.java
+++ b/src/main/java/io/github/robsonkades/uuidv7/UUIDv7.java
@@ -1,8 +1,17 @@
 package io.github.robsonkades.uuidv7;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Static factory for generating UUID version 7 values.
@@ -12,37 +21,71 @@ import java.util.concurrent.atomic.AtomicLong;
  * the version and variant fields mandated by the specification, and 74 bits
  * available for uniqueness and monotonic sequencing.</p>
  *
- * <p>The class exposes two generation strategies:</p>
+ * <p>The class exposes the following generation strategies:</p>
  * <ul>
  *   <li>{@link #randomUUID()} favors throughput and scalability. It uses
  *   per-thread state, avoids shared hot-path contention, and guarantees that
  *   values produced by the same thread remain strictly increasing even when
  *   multiple UUIDs are created within the same millisecond.</li>
+ *   <li>{@link #randomUUIDString()} produces the canonical 36-character string
+ *   form directly, skipping the intermediate {@link UUID} allocation.</li>
+ *   <li>{@link #fill(long[], int, int)} and {@link #fill(byte[], int, int)}
+ *   generate UUIDs in bulk with zero allocations, amortizing clock reads and
+ *   per-thread state lookups across the whole batch.</li>
  *   <li>{@link #secureRandomUUID()} favors unpredictability. It uses
  *   {@link SecureRandom} to seed and advance the random fields, which improves
  *   resistance to prediction at a materially higher cost per UUID.</li>
  * </ul>
  *
- * <p>Both methods are thread-safe. Ordering guarantees are intentionally local:
- * this implementation avoids a single global sequencer in order to preserve
- * multicore scalability, so it does not attempt to impose a total order across
- * all threads.</p>
+ * <p>For callers that already confine work to a single thread (event loops,
+ * actors, partitioned pipelines), {@link UUIDv7Generator} offers an instance
+ * API without the per-call {@link ThreadLocal} lookup.</p>
+ *
+ * <p>All static methods are thread-safe, including when invoked from virtual
+ * threads: virtual threads are transparently routed to a striped pool of
+ * generator states so that neither per-thread state churn nor per-thread
+ * {@link SecureRandom} construction can degrade throughput. Ordering
+ * guarantees are intentionally local: this implementation avoids a single
+ * global sequencer in order to preserve multicore scalability, so it does not
+ * attempt to impose a total order across all threads.</p>
+ *
+ * <p>Since the UUIDv7 timestamp has millisecond granularity, the wall clock
+ * only needs to be observed once per millisecond. Setting the system property
+ * {@value #CACHED_CLOCK_PROPERTY} to {@code true} enables a cached clock
+ * updated by a daemon thread roughly every 0.5&nbsp;ms, replacing the
+ * {@link System#currentTimeMillis()} call on the hot path with a plain
+ * volatile read. The monotonic state machine absorbs the (at most one to two
+ * millisecond) jitter this introduces, so ordering and uniqueness guarantees
+ * are unaffected; only the embedded creation timestamp may lag the true wall
+ * clock by that amount.</p>
  *
  * <p>Edge conditions are handled defensively. If the observed wall clock moves
  * backwards, generation continues from the last emitted timestamp and advances
- * the monotonic state instead of emitting a smaller UUID. If the generator
- * exhausts the available counter space for the active timestamp, it advances to
- * the next logical millisecond rather than knowingly wrapping and returning a
- * duplicate value.</p>
+ * the monotonic state instead of emitting a smaller UUID. Following the
+ * counter-seeding guidance of RFC 9562 Section 6.2, the two most significant
+ * bits of the monotonic {@code rand_b} counter are seeded to zero, which
+ * guarantees at least 2^60 increments of headroom per millisecond; if the
+ * counter space is nevertheless exhausted, the generator advances to the next
+ * logical millisecond rather than knowingly wrapping and returning a duplicate
+ * value.</p>
  *
  * <p>UUIDv7 exposes creation time by design. Even when the secure generation
  * path is used, these identifiers should not be treated as authentication
  * tokens, bearer secrets, or opaque security credentials.</p>
  *
+ * <p>GraalVM native image: this package must be initialized at run time so
+ * that random seeds are not frozen into the image heap at build time. The
+ * published JAR embeds the required {@code native-image.properties}, so no
+ * extra configuration is needed by users.</p>
+ *
  * <p>Example usage:</p>
  * <pre>{@code
  * UUID id = UUIDv7.randomUUID();
+ * String key = UUIDv7.randomUUIDString();
  * UUID secureId = UUIDv7.secureRandomUUID();
+ *
+ * long[] batch = new long[2 * 1024];
+ * UUIDv7.fill(batch, 0, 1024); // 1024 UUIDs, zero allocations
  * }</pre>
  *
  * @see <a href="https://www.rfc-editor.org/rfc/rfc9562.html">RFC 9562</a>
@@ -53,12 +96,35 @@ public final class UUIDv7 {
     static final int RAND_A_MASK = 0x0FFF;
     static final long RAND_B_MASK = 0x3FFFFFFFFFFFFFFFL;
 
+    /**
+     * Seed mask for the monotonic {@code rand_b} counter. Per RFC 9562
+     * Section 6.2 (fixed-length dedicated counter seeding), the two most
+     * significant counter bits are seeded to zero so that every millisecond
+     * starts with at least 2^60 increments of guaranteed headroom, making
+     * counter rollover unreachable in practice.
+     */
+    static final long RAND_B_SEED_MASK = RAND_B_MASK >>> 2;
+
+    /**
+     * Name of the boolean system property that enables the cached millisecond
+     * clock ({@code io.github.robsonkades.uuidv7.cachedClock}). When enabled, a
+     * daemon thread refreshes a volatile timestamp roughly every 0.5&nbsp;ms
+     * and the generators read that instead of calling
+     * {@link System#currentTimeMillis()} on every UUID.
+     */
+    public static final String CACHED_CLOCK_PROPERTY = "io.github.robsonkades.uuidv7.cachedClock";
+
     private static final long VERSION_BITS = 0x0000000000007000L;
     private static final long VARIANT_BITS = 0x8000000000000000L;
     private static final long SPLITMIX64_GAMMA = 0x9E3779B97F4A7C15L;
 
-    private static final AtomicLong SEEDER = new AtomicLong(
-            mix64(System.nanoTime()) ^ mix64(System.currentTimeMillis()));
+    private static final byte[] HEX_DIGITS = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+    };
+
+    static final VarHandle LONG_BE =
+            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
 
     private static final ThreadLocal<GeneratorState> FAST_STATE =
             ThreadLocal.withInitial(UUIDv7::newGeneratorState);
@@ -75,7 +141,8 @@ public final class UUIDv7 {
      * <p>This method uses a per-thread generator state backed by a fast
      * non-cryptographic mixing function. It avoids global locks, shared atomics,
      * temporary buffers, and other coordination points that would otherwise
-     * limit throughput under contention.</p>
+     * limit throughput under contention. Virtual threads are routed to a
+     * striped pool of states instead of per-thread state.</p>
      *
      * <p>Within a single thread, values are strictly increasing even when
      * several UUIDs are created during the same millisecond. Across different
@@ -92,18 +159,105 @@ public final class UUIDv7 {
      *         48-bit UUIDv7 timestamp range
      */
     public static UUID randomUUID() {
-        return FAST_STATE.get().next(currentUnixTimestamp());
+        long unixTsMs = currentUnixTimestamp();
+        if (VirtualThreads.current()) {
+            return FastStripes.next(unixTsMs);
+        }
+        return FAST_STATE.get().next(unixTsMs);
+    }
+
+    /**
+     * Generates a UUIDv7 and returns its canonical 36-character string form.
+     *
+     * <p>Equivalent to {@code randomUUID().toString()} but formats the value
+     * directly from the generator state, skipping the intermediate
+     * {@link UUID} allocation.</p>
+     *
+     * @return the canonical lowercase hexadecimal representation of a new
+     *         RFC 9562-compliant UUIDv7
+     * @throws IllegalStateException if the system time exceeds the representable
+     *         48-bit UUIDv7 timestamp range
+     */
+    public static String randomUUIDString() {
+        long unixTsMs = currentUnixTimestamp();
+        if (VirtualThreads.current()) {
+            return FastStripes.nextString(unixTsMs);
+        }
+        GeneratorState state = FAST_STATE.get();
+        state.advance(unixTsMs);
+        return toCanonicalString(state.msb(), state.lsb());
+    }
+
+    /**
+     * Generates {@code count} UUIDv7 values into {@code dst} as
+     * {@code (mostSignificantBits, leastSignificantBits)} pairs, starting at
+     * {@code offset}. Writes {@code 2 * count} longs and allocates nothing.
+     *
+     * <p>The wall clock is read once for the whole batch and the generated
+     * values are strictly increasing within the batch, so this is the highest
+     * throughput API offered by this class.</p>
+     *
+     * @param dst    destination array
+     * @param offset index of the first long written
+     * @param count  number of UUIDs to generate
+     * @throws IndexOutOfBoundsException if the range
+     *         {@code [offset, offset + 2 * count)} is not within {@code dst}
+     * @throws IllegalStateException if the system time exceeds the representable
+     *         48-bit UUIDv7 timestamp range
+     */
+    public static void fill(long[] dst, int offset, int count) {
+        Objects.checkFromIndexSize(offset, Math.multiplyExact(count, 2), dst.length);
+        if (count == 0) {
+            return;
+        }
+        long unixTsMs = currentUnixTimestamp();
+        if (VirtualThreads.current()) {
+            FastStripes.fill(dst, offset, count, unixTsMs);
+            return;
+        }
+        FAST_STATE.get().fill(dst, offset, count, unixTsMs);
+    }
+
+    /**
+     * Generates {@code count} UUIDv7 values into {@code dst} in the RFC 9562
+     * big-endian binary layout (16 bytes per UUID), starting at {@code offset}.
+     * Writes {@code 16 * count} bytes and allocates nothing.
+     *
+     * <p>The wall clock is read once for the whole batch and the generated
+     * values are strictly increasing within the batch.</p>
+     *
+     * @param dst    destination array
+     * @param offset index of the first byte written
+     * @param count  number of UUIDs to generate
+     * @throws IndexOutOfBoundsException if the range
+     *         {@code [offset, offset + 16 * count)} is not within {@code dst}
+     * @throws IllegalStateException if the system time exceeds the representable
+     *         48-bit UUIDv7 timestamp range
+     */
+    public static void fill(byte[] dst, int offset, int count) {
+        Objects.checkFromIndexSize(offset, Math.multiplyExact(count, 16), dst.length);
+        if (count == 0) {
+            return;
+        }
+        long unixTsMs = currentUnixTimestamp();
+        if (VirtualThreads.current()) {
+            FastStripes.fill(dst, offset, count, unixTsMs);
+            return;
+        }
+        FAST_STATE.get().fill(dst, offset, count, unixTsMs);
     }
 
     /**
      * Generates a UUIDv7 using {@link SecureRandom}-backed entropy.
      *
      * <p>This method preserves the same RFC 9562 bit layout as
-     * {@link #randomUUID()}, but it uses a per-thread {@link SecureRandom}
-     * instance to seed the random fields for each timestamp and to advance the
-     * monotonic state while the timestamp remains unchanged. The result is more
-     * resistant to prediction than the fast path, at a substantially lower
-     * throughput and with higher allocation and provider cost.</p>
+     * {@link #randomUUID()}, but it draws the random fields from a per-thread
+     * {@link SecureRandom}. Entropy is fetched in 512-byte blocks and buffered
+     * in the per-thread state, amortizing the provider and lock costs of
+     * {@link SecureRandom} over many UUIDs; note that this keeps a small block
+     * of random material resident in the heap between calls. Virtual threads
+     * are routed to a striped pool so that no {@link SecureRandom} instance is
+     * ever constructed per virtual thread.</p>
      *
      * <p>Use this method only when stronger entropy properties are required for
      * the UUID payload itself. It is still not a substitute for dedicated secret
@@ -115,7 +269,11 @@ public final class UUIDv7 {
      *         48-bit UUIDv7 timestamp range
      */
     public static UUID secureRandomUUID() {
-        return SECURE_STATE.get().next(currentUnixTimestamp());
+        long unixTsMs = currentUnixTimestamp();
+        if (VirtualThreads.current()) {
+            return SecureStripes.next(unixTsMs);
+        }
+        return SECURE_STATE.get().next(unixTsMs);
     }
 
     static UUID assemble(long unixTsMs, int randA, long randB) {
@@ -145,14 +303,19 @@ public final class UUIDv7 {
         return Long.compareUnsigned(left.getLeastSignificantBits(), right.getLeastSignificantBits());
     }
 
-    private static GeneratorState newGeneratorState() {
+    static GeneratorState newGeneratorState() {
         long threadId = Thread.currentThread().getId();
-        long seed = SEEDER.getAndAdd(SPLITMIX64_GAMMA) ^ mix64(threadId) ^ mix64(System.nanoTime());
+        long seed = Seeder.NEXT.getAndAdd(SPLITMIX64_GAMMA) ^ mix64(threadId) ^ mix64(System.nanoTime());
         return new GeneratorState(seed);
     }
 
-    private static long currentUnixTimestamp() {
-        return normalizeTimestamp(System.currentTimeMillis());
+    /**
+     * Reads and normalizes the current wall-clock millisecond. This is the only
+     * place where normalization happens on the hot path; the generator states
+     * trust that their input is already within the 48-bit range.
+     */
+    static long currentUnixTimestamp() {
+        return normalizeTimestamp(WallClock.now());
     }
 
     private static long normalizeTimestamp(long unixTsMs) {
@@ -173,26 +336,293 @@ public final class UUIDv7 {
     }
 
     /**
+     * Formats {@code (msb, lsb)} as the canonical lowercase UUID string without
+     * materializing a {@link UUID}.
+     */
+    static String toCanonicalString(long msb, long lsb) {
+        byte[] buf = new byte[36];
+        writeHex(buf, 0, msb >>> 32, 8);
+        buf[8] = '-';
+        writeHex(buf, 9, msb >>> 16, 4);
+        buf[13] = '-';
+        writeHex(buf, 14, msb, 4);
+        buf[18] = '-';
+        writeHex(buf, 19, lsb >>> 48, 4);
+        buf[23] = '-';
+        writeHex(buf, 24, lsb, 12);
+        return new String(buf, StandardCharsets.ISO_8859_1);
+    }
+
+    private static void writeHex(byte[] dst, int pos, long value, int digits) {
+        for (int shift = (digits - 1) << 2; shift >= 0; shift -= 4) {
+            dst[pos++] = HEX_DIGITS[(int) (value >>> shift) & 0xF];
+        }
+    }
+
+    private static int stripeCount() {
+        int target = Runtime.getRuntime().availableProcessors() * 4;
+        int size = 1;
+        while (size < target) {
+            size <<= 1;
+        }
+        return size;
+    }
+
+    /**
+     * Holder for the shared seed sequence. Kept in its own class so that
+     * GraalVM native image initializes it at run time; a build-time-initialized
+     * seed would bake the same SplitMix64 sequence into every process started
+     * from the same image.
+     */
+    private static final class Seeder {
+        static final AtomicLong NEXT = new AtomicLong(
+                mix64(System.nanoTime()) ^ mix64(System.currentTimeMillis()));
+    }
+
+    /**
+     * Clock indirection. {@code CACHED} is a JIT-time constant after class
+     * initialization, so the untaken branch is eliminated from compiled code.
+     */
+    private static final class WallClock {
+        static final boolean CACHED = Boolean.getBoolean(CACHED_CLOCK_PROPERTY);
+
+        static long now() {
+            return CACHED ? Ticker.nowMillis : System.currentTimeMillis();
+        }
+    }
+
+    /**
+     * Lazy holder for the cached clock. Only initialized (and only starts its
+     * daemon thread) when the cached clock property is enabled and the first
+     * UUID is generated. The volatile read on the hot path compiles to a plain
+     * load on x86; the cache line is shared read-mostly and invalidated once
+     * per refresh, so cross-core coherence traffic is negligible.
+     */
+    private static final class Ticker {
+        static volatile long nowMillis = System.currentTimeMillis();
+
+        static {
+            Thread ticker = new Thread(Ticker::run, "uuidv7-clock-ticker");
+            ticker.setDaemon(true);
+            ticker.start();
+        }
+
+        private static void run() {
+            while (true) {
+                nowMillis = System.currentTimeMillis();
+                LockSupport.parkNanos(500_000L);
+            }
+        }
+    }
+
+    /**
+     * Reflective probe for {@code Thread.isVirtual()} so the library can run on
+     * Java 17 while still detecting virtual threads on Java 21+. The method
+     * handle is a JIT-time constant: on Java 17 the {@code null} check folds to
+     * {@code false}, on Java 21+ the {@code invokeExact} inlines to the plain
+     * flag test inside {@code Thread.isVirtual()}.
+     */
+    private static final class VirtualThreads {
+        static final MethodHandle IS_VIRTUAL = lookupIsVirtual();
+
+        private static MethodHandle lookupIsVirtual() {
+            try {
+                return MethodHandles.publicLookup()
+                        .findVirtual(Thread.class, "isVirtual", MethodType.methodType(boolean.class));
+            } catch (NoSuchMethodException | IllegalAccessException e) {
+                return null;
+            }
+        }
+
+        static boolean current() {
+            MethodHandle isVirtual = IS_VIRTUAL;
+            if (isVirtual == null) {
+                return false;
+            }
+            try {
+                return (boolean) isVirtual.invokeExact(Thread.currentThread());
+            } catch (Throwable t) {
+                throw new IllegalStateException("Thread.isVirtual() probe failed", t);
+            }
+        }
+    }
+
+    /**
+     * Striped generator pool used by virtual threads. Creating one state per
+     * virtual thread would allocate and reseed on effectively every request in
+     * thread-per-request servers, so virtual threads share a fixed pool of
+     * padded states indexed by thread id, each guarded by a virtual-thread
+     * friendly {@link ReentrantLock}.
+     */
+    private static final class FastStripes {
+        static final FastStripe[] STRIPES = createStripes();
+        static final int MASK = STRIPES.length - 1;
+
+        private static FastStripe[] createStripes() {
+            FastStripe[] stripes = new FastStripe[stripeCount()];
+            for (int i = 0; i < stripes.length; i++) {
+                stripes[i] = new FastStripe();
+            }
+            return stripes;
+        }
+
+        static FastStripe stripe() {
+            return STRIPES[(int) mix64(Thread.currentThread().getId()) & MASK];
+        }
+
+        static UUID next(long unixTsMs) {
+            return stripe().next(unixTsMs);
+        }
+
+        static String nextString(long unixTsMs) {
+            return stripe().nextString(unixTsMs);
+        }
+
+        static void fill(long[] dst, int offset, int count, long unixTsMs) {
+            stripe().fill(dst, offset, count, unixTsMs);
+        }
+
+        static void fill(byte[] dst, int offset, int count, long unixTsMs) {
+            stripe().fill(dst, offset, count, unixTsMs);
+        }
+    }
+
+    static final class FastStripe {
+
+        final ReentrantLock lock = new ReentrantLock();
+        final GeneratorState state = newGeneratorState();
+
+        UUID next(long unixTsMs) {
+            long msb;
+            long lsb;
+            lock.lock();
+            try {
+                state.advance(unixTsMs);
+                msb = state.msb();
+                lsb = state.lsb();
+            } finally {
+                lock.unlock();
+            }
+            return new UUID(msb, lsb);
+        }
+
+        String nextString(long unixTsMs) {
+            long msb;
+            long lsb;
+            lock.lock();
+            try {
+                state.advance(unixTsMs);
+                msb = state.msb();
+                lsb = state.lsb();
+            } finally {
+                lock.unlock();
+            }
+            return toCanonicalString(msb, lsb);
+        }
+
+        void fill(long[] dst, int offset, int count, long unixTsMs) {
+            lock.lock();
+            try {
+                state.fill(dst, offset, count, unixTsMs);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        void fill(byte[] dst, int offset, int count, long unixTsMs) {
+            lock.lock();
+            try {
+                state.fill(dst, offset, count, unixTsMs);
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Striped pool for the secure generator, used by virtual threads. This
+     * bounds the number of {@link SecureRandom} instances to the stripe count
+     * instead of one per virtual thread.
+     */
+    private static final class SecureStripes {
+        static final SecureStripe[] STRIPES = createStripes();
+        static final int MASK = STRIPES.length - 1;
+
+        private static SecureStripe[] createStripes() {
+            SecureStripe[] stripes = new SecureStripe[stripeCount()];
+            for (int i = 0; i < stripes.length; i++) {
+                stripes[i] = new SecureStripe();
+            }
+            return stripes;
+        }
+
+        static UUID next(long unixTsMs) {
+            return STRIPES[(int) mix64(Thread.currentThread().getId()) & MASK].next(unixTsMs);
+        }
+    }
+
+    static final class SecureStripe {
+
+        final ReentrantLock lock = new ReentrantLock();
+        final SecureGeneratorState state = new SecureGeneratorState();
+
+        UUID next(long unixTsMs) {
+            long msb;
+            long lsb;
+            lock.lock();
+            try {
+                state.advance(unixTsMs);
+                msb = state.msb();
+                lsb = state.lsb();
+            } finally {
+                lock.unlock();
+            }
+            return new UUID(msb, lsb);
+        }
+    }
+
+    /**
+     * Leading cache-line padding for {@link GeneratorState}. Generator states
+     * are thread-confined, but compacting garbage collectors may relocate two
+     * states from different threads onto the same 64-byte cache line, turning
+     * every {@code randB} write into cross-core coherence traffic. The
+     * pre/post padding (56 bytes each) guarantees the hot fields never share a
+     * cache line with a neighboring object, regardless of heap layout. Field
+     * layout is reliable because the JVM never interleaves fields across
+     * classes in a hierarchy.
+     */
+    abstract static class GeneratorStatePrePad {
+        long pp00, pp01, pp02, pp03, pp04, pp05, pp06;
+    }
+
+    abstract static class GeneratorStateFields extends GeneratorStatePrePad {
+        long lastUnixTsMs = -1L;
+        long splitMix64State;
+        int randA;
+        long randB;
+    }
+
+    /**
      * Per-thread state for the high-throughput generator.
      *
      * <p>The invariants are:</p>
      * <ul>
-     *   <li>{@code lastUnixTsMs} is the logical timestamp used for the next UUID.</li>
-     *   <li>{@code randA} is randomized whenever the logical timestamp advances.</li>
+     *   <li>{@code lastUnixTsMs} is the logical timestamp used for the next UUID
+     *   and is always within the 48-bit range.</li>
+     *   <li>{@code randA} is randomized whenever the logical timestamp advances
+     *   and always fits in 12 bits.</li>
      *   <li>{@code randB} acts as a monotonic counter while the logical timestamp
-     *   remains unchanged.</li>
+     *   remains unchanged, is reseeded with its two most significant bits clear
+     *   (RFC 9562 Section 6.2), and always fits in 62 bits.</li>
      * </ul>
      *
      * <p>The state is intentionally thread-confined. That removes the need for
      * atomics or locks on the hot path and avoids cache-line contention between
      * producers.</p>
      */
-    static final class GeneratorState {
+    static final class GeneratorState extends GeneratorStateFields {
 
-        private long lastUnixTsMs = -1L;
-        private long splitMix64State;
-        private int randA;
-        private long randB;
+        long tp00, tp01, tp02, tp03, tp04, tp05, tp06;
 
         GeneratorState(long seed) {
             this.splitMix64State = seed;
@@ -206,27 +636,66 @@ public final class UUIDv7 {
         }
 
         /**
-         * Produce the next UUID for the supplied wall-clock millisecond.
-         *
-         * <p>If wall-clock time advances, the random fields are reseeded for the
-         * new timestamp. If time stays the same or moves backwards, the method
-         * keeps the previous logical timestamp and advances the monotonic state
-         * instead so that the returned UUID remains greater than the previous
-         * value produced by this state instance.</p>
+         * Produce the next UUID for the supplied (already normalized)
+         * wall-clock millisecond.
          */
-        UUID next(long requestedUnixTsMs) {
-            long unixTsMs = normalizeTimestamp(requestedUnixTsMs);
+        UUID next(long unixTsMs) {
+            advance(unixTsMs);
+            return new UUID(msb(), lsb());
+        }
 
+        /**
+         * Advance the state for the supplied wall-clock millisecond. If time
+         * advances, the random fields are reseeded for the new timestamp. If
+         * time stays the same or moves backwards, the previous logical
+         * timestamp is kept and the monotonic counter advances instead, so the
+         * next value remains greater than the previous one produced by this
+         * state instance.
+         */
+        void advance(long unixTsMs) {
             if (unixTsMs > lastUnixTsMs) {
                 lastUnixTsMs = unixTsMs;
                 reseed();
-            } else if (unixTsMs == lastUnixTsMs) {
-                incrementCounter();
             } else {
                 incrementCounter();
             }
+        }
 
-            return assemble(lastUnixTsMs, randA, randB);
+        /**
+         * Bulk generation: the clock is observed once for the whole batch and
+         * the state fields stay in registers inside the loop. Values are
+         * strictly increasing within the batch.
+         */
+        void fill(long[] dst, int offset, int count, long unixTsMs) {
+            int idx = offset;
+            for (int i = 0; i < count; i++) {
+                advance(unixTsMs);
+                dst[idx] = msb();
+                dst[idx + 1] = lsb();
+                idx += 2;
+            }
+        }
+
+        void fill(byte[] dst, int offset, int count, long unixTsMs) {
+            int idx = offset;
+            for (int i = 0; i < count; i++) {
+                advance(unixTsMs);
+                LONG_BE.set(dst, idx, msb());
+                LONG_BE.set(dst, idx + 8, lsb());
+                idx += 16;
+            }
+        }
+
+        /**
+         * No masking needed: the class invariants guarantee every field is
+         * already within its RFC 9562 range.
+         */
+        long msb() {
+            return (lastUnixTsMs << 16) | VERSION_BITS | randA;
+        }
+
+        long lsb() {
+            return VARIANT_BITS | randB;
         }
 
         /**
@@ -234,20 +703,23 @@ public final class UUIDv7 {
          *
          * <p>The fast generator uses SplitMix64 output as a per-thread source of
          * high-quality mixed bits. This is a throughput-oriented choice rather
-         * than a cryptographic one.</p>
+         * than a cryptographic one. The counter seed keeps its two most
+         * significant bits clear per RFC 9562 Section 6.2 so that same-millisecond
+         * headroom is always at least 2^60.</p>
          */
         private void reseed() {
             randA = (int) nextLong() & RAND_A_MASK;
-            randB = nextLong() & RAND_B_MASK;
+            randB = nextLong() & RAND_B_SEED_MASK;
         }
 
         /**
          * Advance the same-timestamp monotonic state.
          *
-         * <p>On overflow, the generator moves to the next logical millisecond
-         * instead of wrapping {@code randB}. Wrapping would knowingly violate the
-         * monotonicity and uniqueness assumptions for values produced by this
-         * state instance.</p>
+         * <p>The seeded headroom makes this branch unreachable in practice; it
+         * is kept for rigor. On overflow, the generator moves to the next
+         * logical millisecond instead of wrapping {@code randB}, which would
+         * knowingly violate the monotonicity and uniqueness assumptions for
+         * values produced by this state instance.</p>
          */
         private void incrementCounter() {
             if (randB == RAND_B_MASK) {
@@ -270,51 +742,64 @@ public final class UUIDv7 {
     /**
      * Per-thread state for the secure generator.
      *
-     * <p>This state machine mirrors {@link GeneratorState} but uses
-     * {@link SecureRandom} both to seed a new timestamp and to choose a positive
-     * random increment while the timestamp remains unchanged. That follows the
-     * RFC 9562 "monotonic random" style more closely than incrementing by one,
-     * but it is substantially slower than the fast generator.</p>
+     * <p>This state machine mirrors {@link GeneratorState} but draws its bits
+     * from {@link SecureRandom}, both to seed a new timestamp and to choose a
+     * positive random increment while the timestamp remains unchanged. That
+     * follows the RFC 9562 "monotonic random" style more closely than
+     * incrementing by one.</p>
+     *
+     * <p>Entropy is fetched from the provider in 512-byte blocks and buffered,
+     * which amortizes the provider cost and its internal lock over dozens of
+     * UUIDs; the earlier design paid a full {@code nextLong()} round-trip per
+     * UUID and discarded 54 of the 64 bits on the increment path.</p>
      */
     static final class SecureGeneratorState {
 
+        private static final int BUFFER_SIZE = 512;
+
         private final SecureRandom secureRandom = new SecureRandom();
+        private final byte[] entropy = new byte[BUFFER_SIZE];
+        private int position = BUFFER_SIZE;
+
         private long lastUnixTsMs = -1L;
         private int randA;
         private long randB;
 
         /**
-         * Produce the next UUID for the supplied wall-clock millisecond using a
-         * {@link SecureRandom}-backed state transition.
+         * Produce the next UUID for the supplied (already normalized)
+         * wall-clock millisecond using a {@link SecureRandom}-backed state
+         * transition.
          */
-        UUID next(long requestedUnixTsMs) {
-            long unixTsMs = normalizeTimestamp(requestedUnixTsMs);
+        UUID next(long unixTsMs) {
+            advance(unixTsMs);
+            return new UUID(msb(), lsb());
+        }
 
+        void advance(long unixTsMs) {
             if (unixTsMs > lastUnixTsMs) {
                 lastUnixTsMs = unixTsMs;
                 reseed();
-            } else if (unixTsMs == lastUnixTsMs) {
-                incrementCounter();
             } else {
                 incrementCounter();
             }
+        }
 
-            return assemble(lastUnixTsMs, randA, randB);
+        long msb() {
+            return (lastUnixTsMs << 16) | VERSION_BITS | randA;
+        }
+
+        long lsb() {
+            return VARIANT_BITS | randB;
         }
 
         /**
          * Reinitialize the UUIDv7 random fields for a new logical timestamp.
-         *
-         * <p>Two secure {@code long} values are used so the implementation can
-         * fill both {@code rand_a} and {@code rand_b} directly without
-         * intermediate arrays.</p>
+         * The counter seed keeps its two most significant bits clear per
+         * RFC 9562 Section 6.2.
          */
         private void reseed() {
-            long upper = secureRandom.nextLong();
-            long lower = secureRandom.nextLong();
-
-            randA = (int) (upper & RAND_A_MASK);
-            randB = (((upper >>> 12) & 0x000FFFFFFFFFFFFFL) << 10) | ((lower >>> 54) & 0x03FFL);
+            randA = (int) nextSecureLong() & RAND_A_MASK;
+            randB = nextSecureLong() & RAND_B_SEED_MASK;
         }
 
         /**
@@ -327,7 +812,7 @@ public final class UUIDv7 {
          * millisecond and reseeds.</p>
          */
         private void incrementCounter() {
-            long increment = (secureRandom.nextLong() & 0x03FFL) + 1L;
+            long increment = nextSecure10Bits() + 1L;
 
             if (RAND_B_MASK - randB < increment) {
                 if (lastUnixTsMs == TIMESTAMP_MASK) {
@@ -338,6 +823,29 @@ public final class UUIDv7 {
                 return;
             }
             randB += increment;
+        }
+
+        private long nextSecureLong() {
+            if (position + 8 > BUFFER_SIZE) {
+                refill();
+            }
+            long value = (long) LONG_BE.get(entropy, position);
+            position += 8;
+            return value;
+        }
+
+        private int nextSecure10Bits() {
+            if (position + 2 > BUFFER_SIZE) {
+                refill();
+            }
+            int value = (((entropy[position] & 0xFF) << 8) | (entropy[position + 1] & 0xFF)) & 0x03FF;
+            position += 2;
+            return value;
+        }
+
+        private void refill() {
+            secureRandom.nextBytes(entropy);
+            position = 0;
         }
     }
 }

--- a/src/main/java/io/github/robsonkades/uuidv7/UUIDv7Generator.java
+++ b/src/main/java/io/github/robsonkades/uuidv7/UUIDv7Generator.java
@@ -1,0 +1,129 @@
+package io.github.robsonkades.uuidv7;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Single-threaded UUIDv7 generator instance.
+ *
+ * <p>This class produces exactly the same RFC 9562-compliant values as
+ * {@link UUIDv7#randomUUID()}, but the generator state is owned by the caller
+ * instead of being looked up through a {@link ThreadLocal} on every call.
+ * For code that already confines work to a single thread — event-loop
+ * handlers, actors, partitioned consumers — this removes the per-call
+ * thread-local map probe from the hot path.</p>
+ *
+ * <p><strong>Instances are NOT thread-safe.</strong> Each instance must be
+ * confined to a single thread, or all access must be externally synchronized.
+ * Sharing an instance across threads without synchronization can produce
+ * duplicate or non-monotonic values. When in doubt, use the static
+ * {@link UUIDv7#randomUUID()} API, which is always safe.</p>
+ *
+ * <p>Values produced by one instance are strictly increasing, including when
+ * multiple UUIDs are created within the same millisecond and when the wall
+ * clock moves backwards.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * // one generator per event-loop thread / partition
+ * UUIDv7Generator generator = UUIDv7Generator.create();
+ *
+ * UUID id = generator.next();
+ * String key = generator.nextString();
+ *
+ * long[] batch = new long[2 * 1024];
+ * generator.fill(batch, 0, 1024); // zero allocations
+ * }</pre>
+ *
+ * @see UUIDv7
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9562.html">RFC 9562</a>
+ */
+public final class UUIDv7Generator {
+
+    private final UUIDv7.GeneratorState state;
+
+    private UUIDv7Generator(UUIDv7.GeneratorState state) {
+        this.state = state;
+    }
+
+    /**
+     * Creates a new independently seeded generator.
+     *
+     * @return a new generator instance; the instance is not thread-safe
+     */
+    public static UUIDv7Generator create() {
+        return new UUIDv7Generator(UUIDv7.newGeneratorState());
+    }
+
+    /**
+     * Generates the next UUIDv7.
+     *
+     * @return a new RFC 9562-compliant UUIDv7, strictly greater than the
+     *         previous value produced by this instance
+     * @throws IllegalStateException if the system time exceeds the representable
+     *         48-bit UUIDv7 timestamp range
+     */
+    public UUID next() {
+        return state.next(UUIDv7.currentUnixTimestamp());
+    }
+
+    /**
+     * Generates the next UUIDv7 and returns its canonical 36-character string
+     * form, skipping the intermediate {@link UUID} allocation.
+     *
+     * @return the canonical lowercase hexadecimal representation of a new
+     *         RFC 9562-compliant UUIDv7
+     * @throws IllegalStateException if the system time exceeds the representable
+     *         48-bit UUIDv7 timestamp range
+     */
+    public String nextString() {
+        state.advance(UUIDv7.currentUnixTimestamp());
+        return UUIDv7.toCanonicalString(state.msb(), state.lsb());
+    }
+
+    /**
+     * Generates {@code count} UUIDv7 values into {@code dst} as
+     * {@code (mostSignificantBits, leastSignificantBits)} pairs, starting at
+     * {@code offset}. Writes {@code 2 * count} longs and allocates nothing.
+     * The wall clock is read once for the whole batch and values are strictly
+     * increasing within the batch.
+     *
+     * @param dst    destination array
+     * @param offset index of the first long written
+     * @param count  number of UUIDs to generate
+     * @throws IndexOutOfBoundsException if the range
+     *         {@code [offset, offset + 2 * count)} is not within {@code dst}
+     * @throws IllegalStateException if the system time exceeds the representable
+     *         48-bit UUIDv7 timestamp range
+     */
+    public void fill(long[] dst, int offset, int count) {
+        Objects.checkFromIndexSize(offset, Math.multiplyExact(count, 2), dst.length);
+        if (count == 0) {
+            return;
+        }
+        state.fill(dst, offset, count, UUIDv7.currentUnixTimestamp());
+    }
+
+    /**
+     * Generates {@code count} UUIDv7 values into {@code dst} in the RFC 9562
+     * big-endian binary layout (16 bytes per UUID), starting at {@code offset}.
+     * Writes {@code 16 * count} bytes and allocates nothing. The wall clock is
+     * read once for the whole batch and values are strictly increasing within
+     * the batch.
+     *
+     * @param dst    destination array
+     * @param offset index of the first byte written
+     * @param count  number of UUIDs to generate
+     * @throws IndexOutOfBoundsException if the range
+     *         {@code [offset, offset + 16 * count)} is not within {@code dst}
+     * @throws IllegalStateException if the system time exceeds the representable
+     *         48-bit UUIDv7 timestamp range
+     */
+    public void fill(byte[] dst, int offset, int count) {
+        Objects.checkFromIndexSize(offset, Math.multiplyExact(count, 16), dst.length);
+        if (count == 0) {
+            return;
+        }
+        state.fill(dst, offset, count, UUIDv7.currentUnixTimestamp());
+    }
+}

--- a/src/main/resources/META-INF/native-image/io.github.robsonkades/uuidv7/native-image.properties
+++ b/src/main/resources/META-INF/native-image/io.github.robsonkades/uuidv7/native-image.properties
@@ -1,0 +1,9 @@
+# GraalVM native image configuration for io.github.robsonkades:uuidv7.
+#
+# The whole package must be initialized at run time. Build-time initialization
+# would freeze the random seed state (UUIDv7$Seeder), the cached clock and its
+# daemon thread (UUIDv7$Ticker), the Thread.isVirtual() method handle
+# (UUIDv7$VirtualThreads), and the SecureRandom-backed striped pools into the
+# image heap — every process started from the same image would then generate
+# the same SplitMix64 sequence, breaking uniqueness across instances.
+Args = --initialize-at-run-time=io.github.robsonkades.uuidv7

--- a/src/test/java/io/github/robsonkades/uuidv7/UUIDv7Benchmark.java
+++ b/src/test/java/io/github/robsonkades/uuidv7/UUIDv7Benchmark.java
@@ -9,10 +9,12 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.nio.ByteBuffer;
@@ -104,6 +106,64 @@ public class UUIDv7Benchmark {
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public UUID latencyNaiveSecureRandomByteBuffer() {
         return naive.next();
+    }
+
+    private static final int BATCH_SIZE = 256;
+
+    @State(Scope.Thread)
+    public static class ThreadBuffers {
+        public final long[] longs = new long[2 * BATCH_SIZE];
+        public final byte[] bytes = new byte[16 * BATCH_SIZE];
+        public final UUIDv7Generator generator = UUIDv7Generator.create();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OperationsPerInvocation(BATCH_SIZE)
+    public long[] optimizedFillLongBatch(ThreadBuffers buffers) {
+        UUIDv7.fill(buffers.longs, 0, BATCH_SIZE);
+        return buffers.longs;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OperationsPerInvocation(BATCH_SIZE)
+    public byte[] optimizedFillByteBatch(ThreadBuffers buffers) {
+        UUIDv7.fill(buffers.bytes, 0, BATCH_SIZE);
+        return buffers.bytes;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public UUID optimizedGeneratorInstance(ThreadBuffers buffers) {
+        return buffers.generator.next();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public String optimizedFastString() {
+        return UUIDv7.randomUUIDString();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Threads(8)
+    public UUID contendedOptimizedFast() {
+        return UUIDv7.randomUUID();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Threads(8)
+    public UUID contendedUuidCreatorFast() {
+        return UuidCreator.getTimeOrderedEpochFast();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Threads(8)
+    public UUID contendedJugEpoch() {
+        return jugEpoch.generate();
     }
 
     static final class LegacyThreadLocalRandomV7 {

--- a/src/test/java/io/github/robsonkades/uuidv7/UUIDv7Test.java
+++ b/src/test/java/io/github/robsonkades/uuidv7/UUIDv7Test.java
@@ -1,8 +1,13 @@
 package io.github.robsonkades.uuidv7;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,9 +16,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UUIDv7Test {
@@ -137,5 +144,188 @@ class UUIDv7Test {
         }
 
         assertEquals(expected, seen.size());
+    }
+
+    @Test
+    void shouldSeedCounterWithHeadroomPerRfc9562Section62() {
+        UUIDv7.GeneratorState state = new UUIDv7.GeneratorState(0x1234_5678_9ABC_DEF0L);
+
+        for (long unixTsMs = 1_000L; unixTsMs < 1_064L; unixTsMs++) {
+            UUID uuid = state.next(unixTsMs);
+            assertEquals(unixTsMs, UUIDv7.extractUnixTimestamp(uuid));
+            assertTrue(UUIDv7.extractRandB(uuid) <= UUIDv7.RAND_B_SEED_MASK,
+                    "freshly seeded rand_b must keep its two most significant bits clear");
+        }
+    }
+
+    @Test
+    void shouldFillLongArrayWithValidMonotonicUuids() {
+        int count = 100;
+        long sentinel = 0xAAAAAAAAAAAAAAAAL;
+        long[] dst = new long[2 * count + 4];
+        java.util.Arrays.fill(dst, sentinel);
+
+        UUIDv7.fill(dst, 2, count);
+
+        UUID previous = null;
+        for (int i = 0; i < count; i++) {
+            UUID current = new UUID(dst[2 + 2 * i], dst[3 + 2 * i]);
+            assertEquals(7, current.version());
+            assertEquals(2, current.variant());
+            if (previous != null) {
+                assertTrue(UUIDv7.compareUnsigned(previous, current) < 0);
+            }
+            previous = current;
+        }
+
+        assertEquals(sentinel, dst[0]);
+        assertEquals(sentinel, dst[1]);
+        assertEquals(sentinel, dst[dst.length - 2]);
+        assertEquals(sentinel, dst[dst.length - 1]);
+    }
+
+    @Test
+    void shouldFillByteArrayWithRfcBigEndianLayout() {
+        int count = 8;
+        byte[] dst = new byte[16 * count];
+
+        UUIDv7.fill(dst, 0, count);
+
+        ByteBuffer buffer = ByteBuffer.wrap(dst);
+        long before = System.currentTimeMillis();
+        UUID previous = null;
+        for (int i = 0; i < count; i++) {
+            UUID current = new UUID(buffer.getLong(), buffer.getLong());
+            assertEquals(7, current.version());
+            assertEquals(2, current.variant());
+            assertTrue(UUIDv7.extractUnixTimestamp(current) <= before + 1_000L);
+            if (previous != null) {
+                assertTrue(UUIDv7.compareUnsigned(previous, current) < 0);
+            }
+            previous = current;
+        }
+    }
+
+    @Test
+    void shouldRejectOutOfBoundsFill() {
+        assertThrows(IndexOutOfBoundsException.class, () -> UUIDv7.fill(new long[4], 0, 3));
+        assertThrows(IndexOutOfBoundsException.class, () -> UUIDv7.fill(new long[4], 3, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> UUIDv7.fill(new long[4], 0, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> UUIDv7.fill(new byte[32], 17, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> UUIDv7.fill(new byte[32], 0, 3));
+    }
+
+    @Test
+    void shouldFormatCanonicalStringRepresentation() {
+        String value = UUIDv7.randomUUIDString();
+
+        UUID parsed = UUID.fromString(value);
+        assertEquals(7, parsed.version());
+        assertEquals(2, parsed.variant());
+        assertEquals(value, parsed.toString());
+    }
+
+    @Test
+    void canonicalStringShouldMatchJdkFormatting() {
+        UUID uuid = UUIDv7.assemble(1_645_557_742_000L, 0x0CC3, 0x18C4DC0C0C07398FL);
+
+        assertEquals(uuid.toString(),
+                UUIDv7.toCanonicalString(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()));
+    }
+
+    @Test
+    void generatorInstanceShouldProduceStrictlyIncreasingValues() {
+        UUIDv7Generator generator = UUIDv7Generator.create();
+
+        UUID previous = generator.next();
+        assertEquals(7, previous.version());
+        assertEquals(2, previous.variant());
+
+        for (int i = 0; i < 10_000; i++) {
+            UUID current = generator.next();
+            assertTrue(UUIDv7.compareUnsigned(previous, current) < 0);
+            previous = current;
+        }
+
+        String value = generator.nextString();
+        UUID parsed = UUID.fromString(value);
+        assertEquals(7, parsed.version());
+        assertTrue(UUIDv7.compareUnsigned(previous, parsed) < 0);
+    }
+
+    @Test
+    void generatorInstanceShouldFillBuffersWithValidValues() {
+        UUIDv7Generator generator = UUIDv7Generator.create();
+
+        long[] longs = new long[2 * 16];
+        generator.fill(longs, 0, 16);
+        for (int i = 0; i < 16; i++) {
+            UUID uuid = new UUID(longs[2 * i], longs[2 * i + 1]);
+            assertEquals(7, uuid.version());
+            assertEquals(2, uuid.variant());
+        }
+
+        byte[] bytes = new byte[16 * 16];
+        generator.fill(bytes, 0, 16);
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        for (int i = 0; i < 16; i++) {
+            UUID uuid = new UUID(buffer.getLong(), buffer.getLong());
+            assertEquals(7, uuid.version());
+            assertEquals(2, uuid.variant());
+        }
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    void shouldGenerateValidUuidsOnVirtualThreadsWhenSupported() throws Exception {
+        Object builder;
+        Method start;
+        try {
+            builder = Thread.class.getMethod("ofVirtual").invoke(null);
+            start = Class.forName("java.lang.Thread$Builder").getMethod("start", Runnable.class);
+        } catch (NoSuchMethodException | ClassNotFoundException e) {
+            Assumptions.assumeTrue(false, "virtual threads are not supported on this JVM");
+            return;
+        }
+
+        int threads = 8;
+        int iterationsPerThread = 5_000;
+        Set<UUID> seen = ConcurrentHashMap.newKeySet(threads * iterationsPerThread);
+        AtomicBoolean monotonicPerThread = new AtomicBoolean(true);
+
+        List<Thread> started = new ArrayList<>(threads);
+        for (int i = 0; i < threads; i++) {
+            Runnable task = () -> {
+                UUID previous = null;
+                for (int j = 0; j < iterationsPerThread; j++) {
+                    UUID current = UUIDv7.randomUUID();
+                    if (current.version() != 7 || current.variant() != 2) {
+                        monotonicPerThread.set(false);
+                    }
+                    if (previous != null && UUIDv7.compareUnsigned(previous, current) >= 0) {
+                        monotonicPerThread.set(false);
+                    }
+                    previous = current;
+                    seen.add(current);
+                }
+            };
+            started.add((Thread) start.invoke(builder, task));
+        }
+        for (Thread thread : started) {
+            thread.join();
+        }
+
+        assertTrue(monotonicPerThread.get(), "values seen by a single virtual thread must be strictly increasing");
+        assertEquals(threads * iterationsPerThread, seen.size());
+
+        Runnable secureTask = () -> {
+            UUID secure = UUIDv7.secureRandomUUID();
+            if (secure.version() != 7 || secure.variant() != 2) {
+                monotonicPerThread.set(false);
+            }
+        };
+        Thread secureThread = (Thread) start.invoke(builder, secureTask);
+        secureThread.join();
+        assertTrue(monotonicPerThread.get());
     }
 }


### PR DESCRIPTION
  - Add UUIDv7.fill(long[]/byte[]) bulk APIs (~0.68 ns/UUID, zero allocations)                                                                
  - Add UUIDv7Generator instance API for thread-confined callers                                                                              
  - Add UUIDv7.randomUUIDString() to skip the intermediate UUID allocation                                                                    
  - Buffer SecureRandom entropy in 512-byte blocks (~65x faster secure path)                                                                  
  - Route virtual threads to striped generator pools (Java 21+)                                                                               
  - Seed rand_b with 2^60 headroom per RFC 9562 Section 6.2                                                                                   
  - Pad generator state against post-GC false sharing                                                                                         
  - Add opt-in cached clock (io.github.robsonkades.uuidv7.cachedClock)                                                                        
  - Initialize seeds at run time on GraalVM native image                                                                                      
  - Add benchmarks profile (target/benchmarks.jar), contended/batch JMH                                                                       
    benchmarks, and 10 new tests; update README with new results